### PR TITLE
22 configure number of days

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "concept",
-    version := "0.1.0-SNAPSHOT",
+    version := "0.1.0",
     scalaVersion := scala3Version,
     libraryDependencies ++= Seq(
       "org.scalameta" %% "munit" % "1.0.0-M6" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "concept",
-    version := "0.1.0",
+    version := "0.2.0-SNAPSHOT",
     scalaVersion := scala3Version,
     libraryDependencies ++= Seq(
       "org.scalameta" %% "munit" % "1.0.0-M6" % Test,

--- a/docs/concept.1.adoc
+++ b/docs/concept.1.adoc
@@ -43,6 +43,9 @@ concept - Run a simulation which explores how beliefs and behaviours spread.
 *-s, --start*=_integer_::
     The simulation start time.
 
+*-e, --end*=_integer_::
+    The simulation end time.
+
 == Resources
 
 *Source code hosting*: https://github.com/0xr0bert/concept

--- a/docs/concept.1.adoc
+++ b/docs/concept.1.adoc
@@ -40,6 +40,9 @@ concept - Run a simulation which explores how beliefs and behaviours spread.
 *-o, --output*=__file_::
     The output file, storing the mutated agents.json(5).
 
+*-s, --start*=_integer_::
+    The simulation start time.
+
 == Resources
 
 *Source code hosting*: https://github.com/0xr0bert/concept

--- a/src/main/scala/dev/r0bert/concept/CLIConfig.scala
+++ b/src/main/scala/dev/r0bert/concept/CLIConfig.scala
@@ -18,6 +18,10 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationships
   *   The [[BasicBelief]]s
   * @param performanceRelationships
   *   The [[PerformanceRelationships]]
+  * @param startTime
+  *   The simulation start time.
+  * @param endTime
+  *   The simulation end time.
   * @author
   *   Robert Greener
   * @since v0.0.1
@@ -27,5 +31,7 @@ final case class CLIConfig(
     agents: Array[BasicAgent] = Array(),
     behaviours: Array[BasicBehaviour] = Array(),
     beliefs: Array[BasicBelief] = Array(),
-    performanceRelationships: PerformanceRelationships = Map.empty
+    performanceRelationships: PerformanceRelationships = Map.empty,
+    startTime: Int = 1,
+    endTime: Int = 100
 )

--- a/src/main/scala/dev/r0bert/concept/Main.scala
+++ b/src/main/scala/dev/r0bert/concept/Main.scala
@@ -132,7 +132,12 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationshipUtils.
         .required()
         .valueName("<integer>")
         .action((i, c) => c.copy(startTime = i))
-        .text("The simulation start time")
+        .text("The simulation start time"),
+      opt[Int]('e', "end")
+        .required()
+        .valueName("<integer>")
+        .action((i, c) => c.copy(endTime = i))
+        .text("The simulation end time")
     )
 
   OParser.parse(parser, args, CLIConfig()) match {

--- a/src/main/scala/dev/r0bert/concept/Main.scala
+++ b/src/main/scala/dev/r0bert/concept/Main.scala
@@ -127,7 +127,12 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationshipUtils.
           else failure(s"$file already exists!")
         )
         .action((f, c) => c.copy(outputFile = f))
-        .text("The output file is a mutated agents.json(5)")
+        .text("The output file is a mutated agents.json(5)"),
+      opt[Int]('s', "start")
+        .required()
+        .valueName("<integer>")
+        .action((i, c) => c.copy(startTime = i))
+        .text("The simulation start time")
     )
 
   OParser.parse(parser, args, CLIConfig()) match {

--- a/src/main/scala/dev/r0bert/concept/Main.scala
+++ b/src/main/scala/dev/r0bert/concept/Main.scala
@@ -143,6 +143,6 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationshipUtils.
   OParser.parse(parser, args, CLIConfig()) match {
     case Some(config) =>
       val runner = Runner(config)
-      runner.run(1, 2)
+      runner.run()
     case None => throw RuntimeException("The supplied data is incorrect")
   }

--- a/src/main/scala/dev/r0bert/concept/Main.scala
+++ b/src/main/scala/dev/r0bert/concept/Main.scala
@@ -16,7 +16,7 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationshipUtils.
     import builder._
     OParser.sequence(
       programName("concept"),
-      head("concept", "v0.1.0"),
+      head("concept", "v0.2.0-SNAPSHOT"),
       version('V', "version")
         .text("Print the version information"),
       help('h', "help")

--- a/src/main/scala/dev/r0bert/concept/Main.scala
+++ b/src/main/scala/dev/r0bert/concept/Main.scala
@@ -16,7 +16,7 @@ import dev.r0bert.concept.performancerelationships.PerformanceRelationshipUtils.
     import builder._
     OParser.sequence(
       programName("concept"),
-      head("concept", "v0.1.0-SNAPSHOT"),
+      head("concept", "v0.1.0"),
       version('V', "version")
         .text("Print the version information"),
       help('h', "help")

--- a/src/main/scala/dev/r0bert/concept/Runner.scala
+++ b/src/main/scala/dev/r0bert/concept/Runner.scala
@@ -27,10 +27,6 @@ class Runner(
 
   /** Run the simulation between time start and end.
     *
-    * @param start
-    *   The start time.
-    * @param end
-    *   The end time.
     * @author
     *   Robert Greener
     * @since v0.0.1

--- a/src/main/scala/dev/r0bert/concept/Runner.scala
+++ b/src/main/scala/dev/r0bert/concept/Runner.scala
@@ -35,14 +35,14 @@ class Runner(
     *   Robert Greener
     * @since v0.0.1
     */
-  def run(start: Int, end: Int): Unit =
+  def run(): Unit =
     logger.info("Starting concept")
     logger.info(s"n beliefs: ${config.beliefs.size}")
     logger.info(s"n behaviours: ${config.behaviours.size}")
     logger.info(s"n agents: ${config.agents.size}")
-    logger.info(s"Start time: ${start}")
-    logger.info(s"End time: ${end}")
-    tickBetween(start, end)
+    logger.info(s"Start time: ${config.startTime}")
+    logger.info(s"End time: ${config.endTime}")
+    tickBetween(config.startTime, config.endTime)
     logger.info(s"Ending concept")
     serializeAgents()
 


### PR DESCRIPTION
Closes #22
- CLIConfig: Add start and end time
- Add start as option to the CLI.
- Add --end as an option.
- Runner: Use start and end time from config
- Release 0.1.0
- Bump version to 0.2.0-SNAPSHOT
- Runner: Remove erroneous documentation
